### PR TITLE
github: use the new GitHub container registry

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -111,9 +111,9 @@ jobs:
       - name: Login to Container Registry
         uses: docker/login-action@v1
         with:
-          registry: docker.pkg.github.com
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ secrets.GH_PAT_USER }}
+          password: ${{ secrets.GH_PAT_TOKEN }}
 
       - name: Build and push
         id: docker_build
@@ -121,7 +121,7 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
-          tags: docker.pkg.github.com/${{ github.repository }}/statsbot:${{ env.BRANCH_NAME }}-${{ env.SHORT_SHA }}
+          tags: ghcr.io/${{ github.repository }}:${{ env.BRANCH_NAME }}-${{ env.SHORT_SHA }}
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
https://docs.github.com/en/free-pro-team@latest/packages/guides/migrating-to-github-container-registry-for-docker-images
