### PR TITLE
bot: selectively enable experimental sentiment analysis

### DIFF
--- a/config.go
+++ b/config.go
@@ -7,16 +7,16 @@ import (
 
 // Config stores application configurations
 type Config struct {
-	StatsbotLogLevel        string `envconfig:"SLACKBOT_LOGLEVEL" default:"warn"`
-	StatsbotLogFormat       string `envconfig:"SLACKBOT_LOGFORMAT" default:"text"`
-	StatsbotPort            string `envconfig:"SLACKBOT_PORT" default:"8080"`
-	StatsbotHost            string `envconfig:"SLACKBOT_HOST" default:"127.0.0.1"`
-	StatsbotEnableSentiment bool   `envconfig:"SLACKBOT_REACTION_SENTIMENT_ENABLE" default:"false"`
-	SlackSigningSecret      string `envconfig:"SLACK_SIGNING_SECRET" required:"true"`
-	SlackOAuthAccessToken   string `envconfig:"SLACK_OAUTH_ACCESS_TOKEN" required:"true"`
-	BigQueryProjectID       string `envconfig:"BIGQUERY_PROJECT_ID" required:"true"`
-	BigQueryDatasetID       string `envconfig:"BIGQUERY_DATASET_ID" required:"true"`
-	BigQueryTableID         string `envconfig:"BIGQUERY_TABLE_ID" required:"true"`
+	LogLevel              string `envconfig:"SLACKBOT_LOGLEVEL" default:"warn"`
+	LogFormat             string `envconfig:"SLACKBOT_LOGFORMAT" default:"text"`
+	Port                  string `envconfig:"SLACKBOT_PORT" default:"8080"`
+	Host                  string `envconfig:"SLACKBOT_HOST" default:"127.0.0.1"`
+	EnableSentiment       bool   `envconfig:"SLACKBOT_REACTION_SENTIMENT_ENABLE" default:"false"`
+	SlackSigningSecret    string `envconfig:"SLACK_SIGNING_SECRET" required:"true"`
+	SlackOAuthAccessToken string `envconfig:"SLACK_OAUTH_ACCESS_TOKEN" required:"true"`
+	BigQueryProjectID     string `envconfig:"BIGQUERY_PROJECT_ID" required:"true"`
+	BigQueryDatasetID     string `envconfig:"BIGQUERY_DATASET_ID" required:"true"`
+	BigQueryTableID       string `envconfig:"BIGQUERY_TABLE_ID" required:"true"`
 }
 
 // ConfigFromEnvironment loads config from env variables and .env file

--- a/logging.go
+++ b/logging.go
@@ -7,7 +7,7 @@ import (
 func setupLogging() {
 	c, _ := ConfigFromEnvironment()
 
-	switch c.StatsbotLogLevel {
+	switch c.LogLevel {
 	case "debug":
 		logrus.SetLevel(logrus.DebugLevel)
 	case "info":
@@ -19,17 +19,17 @@ func setupLogging() {
 	case "fatal":
 		logrus.SetLevel(logrus.FatalLevel)
 	default:
-		logrus.WithField("log-level", c.StatsbotLogLevel).Warning("invalid log level. defaulting to info.")
+		logrus.WithField("log-level", c.LogLevel).Warning("invalid log level. defaulting to info.")
 		logrus.SetLevel(logrus.InfoLevel)
 	}
 
-	switch c.StatsbotLogFormat {
+	switch c.LogFormat {
 	case "text":
 		logrus.SetFormatter(new(logrus.TextFormatter))
 	case "json":
 		logrus.SetFormatter(new(logrus.JSONFormatter))
 	default:
-		logrus.WithField("log-format", c.StatsbotLogFormat).Warning("invalid log format. defaulting to text.")
+		logrus.WithField("log-format", c.LogFormat).Warning("invalid log format. defaulting to text.")
 		logrus.SetFormatter(new(logrus.TextFormatter))
 	}
 }


### PR DESCRIPTION
Set `STATSBOT_SENTIMENT_ENABLE` to enable experimental support for sentiment
text analysis.

Related to #15
